### PR TITLE
Graphql relay

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -26,12 +26,16 @@ config :logger, :console,
 config :ueberauth, Ueberauth,
   providers: [ google: { Ueberauth.Strategy.Google, [] } ]
 
+config :graphql_relay,
+  schema_module: TestSchema,
+  schema_json_path: "#{Path.dirname(__DIR__)}/priv/graphql"
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{Mix.env}.exs"
 
 Logger.debug "Loading secrets if present"
-if File.exists?("config/#{Mix.env}.secret.exs") do
+if File.exists?("#{Path.dirname(__DIR__)}/config/#{Mix.env}.secret.exs") do
   import_config "#{Mix.env}.secret.exs"
   Logger.debug "Secrets loaded."
 else

--- a/config/config.exs
+++ b/config/config.exs
@@ -27,7 +27,7 @@ config :ueberauth, Ueberauth,
   providers: [ google: { Ueberauth.Strategy.Google, [] } ]
 
 config :graphql_relay,
-  schema_module: TestSchema,
+  schema_module: EdmBackend.GraphQL.Schema,
   schema_json_path: "#{Path.dirname(__DIR__)}/priv/graphql"
 
 # Import environment specific config. This must remain at the bottom

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -35,6 +35,7 @@ config :eye_drops,
     %{
       id: :graphql_update_schema,
       name: "Update GraphQL Schema",
+      run_on_start: true,
       cmd: "mix graphql.gen.schema",
       paths: ["web/graphql/*"] # path to graphql files
     }

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -14,7 +14,8 @@ config :edm_backend, EdmBackend.Endpoint,
   code_reloader: true,
   check_origin: false,
   watchers: [node: ["node_modules/brunch/bin/brunch", "watch", "--stdin",
-                    cd: Path.expand("../", __DIR__)]]
+                    cd: Path.expand("../", __DIR__)],
+             mix: ["eye_drops", cd: Path.expand("../", __DIR__)]]
 
 
 # Watch static and templates for browser reloading.
@@ -26,6 +27,17 @@ config :edm_backend, EdmBackend.Endpoint,
       ~r{web/views/.*(ex)$},
       ~r{web/templates/.*(eex)$}
     ]
+  ]
+
+# Update the graphql schema json file
+config :eye_drops,
+  tasks: [
+    %{
+      id: :graphql_update_schema,
+      name: "Update GraphQL Schema",
+      cmd: "mix graphql.gen.schema",
+      paths: ["web/graphql/*"] # path to graphql files
+    }
   ]
 
 # Do not include metadata nor timestamps in development logs

--- a/lib/mix/tasks/graphql.gen.schema.ex
+++ b/lib/mix/tasks/graphql.gen.schema.ex
@@ -1,0 +1,13 @@
+defmodule Mix.Tasks.Graphql.Gen.Schema do
+  @moduledoc """
+  Updates GraphQL schema.json file.
+  """
+
+  use Mix.Task
+
+  @doc false
+  def run(_args) do
+    GraphQL.Relay.generate_schema_json!
+    System.cmd("brunch", ["build"])
+  end
+end

--- a/lib/mix/tasks/graphql.gen.schema.ex
+++ b/lib/mix/tasks/graphql.gen.schema.ex
@@ -8,6 +8,6 @@ defmodule Mix.Tasks.Graphql.Gen.Schema do
   @doc false
   def run(_args) do
     GraphQL.Relay.generate_schema_json!
-    System.cmd("brunch", ["build"])
+    System.cmd("#{Path.expand("../../../",__DIR__)}/node_modules/brunch/bin/brunch", ["build"])
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -69,7 +69,8 @@ defmodule EdmBackend.Mixfile do
      {:ueberauth_google, "~> 0.2"},
 
      # GraphQL support
-     {:plug_graphql, "~> 0.3.1"}]
+     {:plug_graphql, "~> 0.3.1"},
+     {:graphql_relay, "~> 0.5"}]
   end
 
   # Aliases are shortcuts or tasks specific to the current project.

--- a/mix.exs
+++ b/mix.exs
@@ -70,7 +70,11 @@ defmodule EdmBackend.Mixfile do
 
      # GraphQL support
      {:plug_graphql, "~> 0.3.1"},
-     {:graphql_relay, "~> 0.5"}]
+     {:graphql_relay, "~> 0.5"},
+
+     # Watch configured tasks
+     # Used to rebuild the graphql/relay json schema
+     {:eye_drops, "~> 1.2"}]
   end
 
   # Aliases are shortcuts or tasks specific to the current project.

--- a/priv/graphql/schema.json
+++ b/priv/graphql/schema.json
@@ -1,0 +1,806 @@
+{
+  "data": {
+    "__schema": {
+      "types": [
+        {
+          "possibleTypes": null,
+          "name": "Boolean",
+          "kind": "SCALAR",
+          "interfaces": null,
+          "inputFields": null,
+          "fields": null,
+          "enumValues": null,
+          "description": "The `Boolean` scalar type represents `true` or `false`."
+        },
+        {
+          "possibleTypes": null,
+          "name": "Hello",
+          "kind": "OBJECT",
+          "interfaces": [],
+          "inputFields": null,
+          "fields": [
+            {
+              "type": {
+                "ofType": null,
+                "name": "String",
+                "kind": "SCALAR"
+              },
+              "name": "greeting",
+              "isDeprecated": null,
+              "description": null,
+              "deprecationReason": null,
+              "args": [
+                {
+                  "type": {
+                    "ofType": null,
+                    "name": "String",
+                    "kind": "SCALAR"
+                  },
+                  "name": "name",
+                  "description": null,
+                  "defaultValue": null
+                }
+              ]
+            }
+          ],
+          "enumValues": null,
+          "description": ""
+        },
+        {
+          "possibleTypes": null,
+          "name": "String",
+          "kind": "SCALAR",
+          "interfaces": null,
+          "inputFields": null,
+          "fields": null,
+          "enumValues": null,
+          "description": "The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text."
+        },
+        {
+          "possibleTypes": null,
+          "name": "__Directive",
+          "kind": "OBJECT",
+          "interfaces": [],
+          "inputFields": null,
+          "fields": [
+            {
+              "type": {
+                "ofType": {
+                  "ofType": {
+                    "ofType": {
+                      "name": "__InputValue",
+                      "kind": "OBJECT"
+                    },
+                    "name": null,
+                    "kind": "NON_NULL"
+                  },
+                  "name": null,
+                  "kind": "LIST"
+                },
+                "name": null,
+                "kind": "NON_NULL"
+              },
+              "name": "args",
+              "isDeprecated": null,
+              "description": null,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "type": {
+                "ofType": null,
+                "name": "String",
+                "kind": "SCALAR"
+              },
+              "name": "description",
+              "isDeprecated": null,
+              "description": null,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "type": {
+                "ofType": {
+                  "ofType": null,
+                  "name": "String",
+                  "kind": "SCALAR"
+                },
+                "name": null,
+                "kind": "NON_NULL"
+              },
+              "name": "name",
+              "isDeprecated": null,
+              "description": null,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "type": {
+                "ofType": {
+                  "ofType": null,
+                  "name": "Boolean",
+                  "kind": "SCALAR"
+                },
+                "name": null,
+                "kind": "NON_NULL"
+              },
+              "name": "onField",
+              "isDeprecated": null,
+              "description": null,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "type": {
+                "ofType": {
+                  "ofType": null,
+                  "name": "Boolean",
+                  "kind": "SCALAR"
+                },
+                "name": null,
+                "kind": "NON_NULL"
+              },
+              "name": "onFragment",
+              "isDeprecated": null,
+              "description": null,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "type": {
+                "ofType": {
+                  "ofType": null,
+                  "name": "Boolean",
+                  "kind": "SCALAR"
+                },
+                "name": null,
+                "kind": "NON_NULL"
+              },
+              "name": "onOperation",
+              "isDeprecated": null,
+              "description": null,
+              "deprecationReason": null,
+              "args": []
+            }
+          ],
+          "enumValues": null,
+          "description": "A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.  In some cases, you need to provide options to alter GraphQL’s execution behavior in ways field arguments will not suffice, such as conditionally including or skipping a field. Directives provide this by describing additional information to the executor"
+        },
+        {
+          "possibleTypes": null,
+          "name": "__EnumValue",
+          "kind": "OBJECT",
+          "interfaces": [],
+          "inputFields": null,
+          "fields": [
+            {
+              "type": {
+                "ofType": null,
+                "name": "String",
+                "kind": "SCALAR"
+              },
+              "name": "deprecationReason",
+              "isDeprecated": null,
+              "description": null,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "type": {
+                "ofType": null,
+                "name": "String",
+                "kind": "SCALAR"
+              },
+              "name": "description",
+              "isDeprecated": null,
+              "description": null,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "type": {
+                "ofType": {
+                  "ofType": null,
+                  "name": "Boolean",
+                  "kind": "SCALAR"
+                },
+                "name": null,
+                "kind": "NON_NULL"
+              },
+              "name": "isDeprecated",
+              "isDeprecated": null,
+              "description": null,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "type": {
+                "ofType": {
+                  "ofType": null,
+                  "name": "String",
+                  "kind": "SCALAR"
+                },
+                "name": null,
+                "kind": "NON_NULL"
+              },
+              "name": "name",
+              "isDeprecated": null,
+              "description": null,
+              "deprecationReason": null,
+              "args": []
+            }
+          ],
+          "enumValues": null,
+          "description": "One possible value for a given Enum. Enum values are unique values, not a placeholder for a string or numeric value. However an Enum value is returned in a JSON response as a string."
+        },
+        {
+          "possibleTypes": null,
+          "name": "__Field",
+          "kind": "OBJECT",
+          "interfaces": [],
+          "inputFields": null,
+          "fields": [
+            {
+              "type": {
+                "ofType": {
+                  "ofType": {
+                    "ofType": {
+                      "name": "__InputValue",
+                      "kind": "OBJECT"
+                    },
+                    "name": null,
+                    "kind": "NON_NULL"
+                  },
+                  "name": null,
+                  "kind": "LIST"
+                },
+                "name": null,
+                "kind": "NON_NULL"
+              },
+              "name": "args",
+              "isDeprecated": null,
+              "description": null,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "type": {
+                "ofType": null,
+                "name": "String",
+                "kind": "SCALAR"
+              },
+              "name": "deprecationReason",
+              "isDeprecated": null,
+              "description": null,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "type": {
+                "ofType": null,
+                "name": "String",
+                "kind": "SCALAR"
+              },
+              "name": "description",
+              "isDeprecated": null,
+              "description": null,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "type": {
+                "ofType": {
+                  "ofType": null,
+                  "name": "Boolean",
+                  "kind": "SCALAR"
+                },
+                "name": null,
+                "kind": "NON_NULL"
+              },
+              "name": "isDeprecated",
+              "isDeprecated": null,
+              "description": null,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "type": {
+                "ofType": {
+                  "ofType": null,
+                  "name": "String",
+                  "kind": "SCALAR"
+                },
+                "name": null,
+                "kind": "NON_NULL"
+              },
+              "name": "name",
+              "isDeprecated": null,
+              "description": null,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "type": {
+                "ofType": {
+                  "ofType": null,
+                  "name": "__Type",
+                  "kind": "OBJECT"
+                },
+                "name": null,
+                "kind": "NON_NULL"
+              },
+              "name": "type",
+              "isDeprecated": null,
+              "description": null,
+              "deprecationReason": null,
+              "args": []
+            }
+          ],
+          "enumValues": null,
+          "description": "Object and Interface types are described by a list of Fields, each of which has a name, potentially a list of arguments, and a return type."
+        },
+        {
+          "possibleTypes": null,
+          "name": "__InputValue",
+          "kind": "OBJECT",
+          "interfaces": [],
+          "inputFields": null,
+          "fields": [
+            {
+              "type": {
+                "ofType": null,
+                "name": "String",
+                "kind": "SCALAR"
+              },
+              "name": "defaultValue",
+              "isDeprecated": null,
+              "description": "A GraphQL-formatted string representing the default value for this input value.",
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "type": {
+                "ofType": null,
+                "name": "String",
+                "kind": "SCALAR"
+              },
+              "name": "description",
+              "isDeprecated": null,
+              "description": null,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "type": {
+                "ofType": {
+                  "ofType": null,
+                  "name": "String",
+                  "kind": "SCALAR"
+                },
+                "name": null,
+                "kind": "NON_NULL"
+              },
+              "name": "name",
+              "isDeprecated": null,
+              "description": null,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "type": {
+                "ofType": {
+                  "ofType": null,
+                  "name": "__Type",
+                  "kind": "OBJECT"
+                },
+                "name": null,
+                "kind": "NON_NULL"
+              },
+              "name": "type",
+              "isDeprecated": null,
+              "description": null,
+              "deprecationReason": null,
+              "args": []
+            }
+          ],
+          "enumValues": null,
+          "description": "Arguments provided to Fields or Directives and the input fields of an InputObject are represented as Input Values which describe their type and optionally a default value."
+        },
+        {
+          "possibleTypes": null,
+          "name": "__Schema",
+          "kind": "OBJECT",
+          "interfaces": [],
+          "inputFields": null,
+          "fields": [
+            {
+              "type": {
+                "ofType": {
+                  "ofType": {
+                    "ofType": {
+                      "name": "__Directive",
+                      "kind": "OBJECT"
+                    },
+                    "name": null,
+                    "kind": "NON_NULL"
+                  },
+                  "name": null,
+                  "kind": "LIST"
+                },
+                "name": null,
+                "kind": "NON_NULL"
+              },
+              "name": "directives",
+              "isDeprecated": null,
+              "description": "A list of all directives supported by this server.",
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "type": {
+                "ofType": null,
+                "name": "__Type",
+                "kind": "OBJECT"
+              },
+              "name": "mutationType",
+              "isDeprecated": null,
+              "description": "If this server supports mutation, the type that mutation operations will be rooted at.",
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "type": {
+                "ofType": {
+                  "ofType": null,
+                  "name": "__Type",
+                  "kind": "OBJECT"
+                },
+                "name": null,
+                "kind": "NON_NULL"
+              },
+              "name": "queryType",
+              "isDeprecated": null,
+              "description": "The type that query operations will be rooted at.",
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "type": {
+                "ofType": null,
+                "name": "__Type",
+                "kind": "OBJECT"
+              },
+              "name": "subscriptionType",
+              "isDeprecated": null,
+              "description": "If this server support subscription, the type that subscription operations will be rooted at.",
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "type": {
+                "ofType": {
+                  "ofType": {
+                    "ofType": {
+                      "name": "__Type",
+                      "kind": "OBJECT"
+                    },
+                    "name": null,
+                    "kind": "NON_NULL"
+                  },
+                  "name": null,
+                  "kind": "LIST"
+                },
+                "name": null,
+                "kind": "NON_NULL"
+              },
+              "name": "types",
+              "isDeprecated": null,
+              "description": "A list of all types supported by this server.",
+              "deprecationReason": null,
+              "args": []
+            }
+          ],
+          "enumValues": null,
+          "description": "A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all available types and directives on the server, as well as the entry points for query, mutation, and subscription operations."
+        },
+        {
+          "possibleTypes": null,
+          "name": "__Type",
+          "kind": "OBJECT",
+          "interfaces": [],
+          "inputFields": null,
+          "fields": [
+            {
+              "type": {
+                "ofType": null,
+                "name": "String",
+                "kind": "SCALAR"
+              },
+              "name": "description",
+              "isDeprecated": null,
+              "description": null,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "type": {
+                "ofType": {
+                  "ofType": {
+                    "ofType": null,
+                    "name": "__EnumValue",
+                    "kind": "OBJECT"
+                  },
+                  "name": null,
+                  "kind": "NON_NULL"
+                },
+                "name": null,
+                "kind": "LIST"
+              },
+              "name": "enumValues",
+              "isDeprecated": null,
+              "description": null,
+              "deprecationReason": null,
+              "args": [
+                {
+                  "type": {
+                    "ofType": null,
+                    "name": "Boolean",
+                    "kind": "SCALAR"
+                  },
+                  "name": "includeDeprecated",
+                  "description": null,
+                  "defaultValue": "false"
+                }
+              ]
+            },
+            {
+              "type": {
+                "ofType": {
+                  "ofType": {
+                    "ofType": null,
+                    "name": "__Field",
+                    "kind": "OBJECT"
+                  },
+                  "name": null,
+                  "kind": "NON_NULL"
+                },
+                "name": null,
+                "kind": "LIST"
+              },
+              "name": "fields",
+              "isDeprecated": null,
+              "description": null,
+              "deprecationReason": null,
+              "args": [
+                {
+                  "type": {
+                    "ofType": null,
+                    "name": "Boolean",
+                    "kind": "SCALAR"
+                  },
+                  "name": "includeDeprecated",
+                  "description": null,
+                  "defaultValue": "false"
+                }
+              ]
+            },
+            {
+              "type": {
+                "ofType": {
+                  "ofType": {
+                    "ofType": null,
+                    "name": "__InputValue",
+                    "kind": "OBJECT"
+                  },
+                  "name": null,
+                  "kind": "NON_NULL"
+                },
+                "name": null,
+                "kind": "LIST"
+              },
+              "name": "inputFields",
+              "isDeprecated": null,
+              "description": null,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "type": {
+                "ofType": {
+                  "ofType": {
+                    "ofType": null,
+                    "name": "__Type",
+                    "kind": "OBJECT"
+                  },
+                  "name": null,
+                  "kind": "NON_NULL"
+                },
+                "name": null,
+                "kind": "LIST"
+              },
+              "name": "interfaces",
+              "isDeprecated": null,
+              "description": null,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "type": {
+                "ofType": {
+                  "ofType": null,
+                  "name": "__TypeKind",
+                  "kind": "ENUM"
+                },
+                "name": null,
+                "kind": "NON_NULL"
+              },
+              "name": "kind",
+              "isDeprecated": null,
+              "description": null,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "type": {
+                "ofType": null,
+                "name": "String",
+                "kind": "SCALAR"
+              },
+              "name": "name",
+              "isDeprecated": null,
+              "description": null,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "type": {
+                "ofType": null,
+                "name": "__Type",
+                "kind": "OBJECT"
+              },
+              "name": "ofType",
+              "isDeprecated": null,
+              "description": null,
+              "deprecationReason": null,
+              "args": []
+            },
+            {
+              "type": {
+                "ofType": {
+                  "ofType": {
+                    "ofType": null,
+                    "name": "__Type",
+                    "kind": "OBJECT"
+                  },
+                  "name": null,
+                  "kind": "NON_NULL"
+                },
+                "name": null,
+                "kind": "LIST"
+              },
+              "name": "possibleTypes",
+              "isDeprecated": null,
+              "description": null,
+              "deprecationReason": null,
+              "args": []
+            }
+          ],
+          "enumValues": null,
+          "description": "The fundamental unit of any GraphQL Schema is the type. There are many kinds of types in GraphQL as represented by the `__TypeKind` enum.  Depending on the kind of a type, certain fields describe information about that type. Scalar types provide no information beyond a name and description, while Enum types provide their values. Object and Interface types provide the fields they describe. Abstract types, Union and Interface, provide the Object types possible at runtime. List and NonNull types compose other types."
+        },
+        {
+          "possibleTypes": null,
+          "name": "__TypeKind",
+          "kind": "ENUM",
+          "interfaces": null,
+          "inputFields": null,
+          "fields": null,
+          "enumValues": [
+            {
+              "name": "ENUM",
+              "isDeprecated": null,
+              "description": "Indicates this type is an enum. `enumValues` is a valid field.",
+              "deprecationReason": null
+            },
+            {
+              "name": "INPUT_OBJECT",
+              "isDeprecated": null,
+              "description": "Indicates this type is an input object. `inputFields` is a valid field.",
+              "deprecationReason": null
+            },
+            {
+              "name": "INTERFACE",
+              "isDeprecated": null,
+              "description": "Indicates this type is an interface. `fields` and `possibleTypes` are valid fields.",
+              "deprecationReason": null
+            },
+            {
+              "name": "LIST",
+              "isDeprecated": null,
+              "description": "Indicates this type is a list. `ofType` is a valid field.",
+              "deprecationReason": null
+            },
+            {
+              "name": "NON_NULL",
+              "isDeprecated": null,
+              "description": "Indicates this type is a non-null. `ofType` is a valid field.",
+              "deprecationReason": null
+            },
+            {
+              "name": "OBJECT",
+              "isDeprecated": null,
+              "description": "Indicates this type is an object. `fields` and `interfaces` are valid fields.",
+              "deprecationReason": null
+            },
+            {
+              "name": "SCALAR",
+              "isDeprecated": null,
+              "description": "Indicates this type is a scalar.",
+              "deprecationReason": null
+            },
+            {
+              "name": "UNION",
+              "isDeprecated": null,
+              "description": "Indicates this type is a union. `possibleTypes` is a valid field.",
+              "deprecationReason": null
+            }
+          ],
+          "description": "An enum describing what kind of type a given `__Type` is."
+        }
+      ],
+      "subscriptionType": null,
+      "queryType": {
+        "name": "Hello"
+      },
+      "mutationType": null,
+      "directives": [
+        {
+          "onOperation": false,
+          "onFragment": true,
+          "onField": true,
+          "name": "include",
+          "description": "Directs the executor to include this field or fragment only when the `if` argument is true.",
+          "args": [
+            {
+              "type": {
+                "ofType": {
+                  "ofType": null,
+                  "name": "Boolean",
+                  "kind": "SCALAR"
+                },
+                "name": null,
+                "kind": "NON_NULL"
+              },
+              "name": "if",
+              "description": "Included when true.",
+              "defaultValue": null
+            }
+          ]
+        },
+        {
+          "onOperation": false,
+          "onFragment": true,
+          "onField": true,
+          "name": "skip",
+          "description": "Directs the executor to skip this field or fragment when the `if` argument is true.",
+          "args": [
+            {
+              "type": {
+                "ofType": {
+                  "ofType": null,
+                  "name": "Boolean",
+                  "kind": "SCALAR"
+                },
+                "name": null,
+                "kind": "NON_NULL"
+              },
+              "name": "if",
+              "description": "Skipped when true.",
+              "defaultValue": null
+            }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/web/graphql/schema.ex
+++ b/web/graphql/schema.ex
@@ -2,7 +2,7 @@ defmodule EdmBackend.GraphQL.Schema do
   def schema do
     %GraphQL.Schema{
       query: %GraphQL.Type.ObjectType{
-        name: "Hello",
+        name: "Helloo",
         fields: %{
           greeting: %{
             type: %GraphQL.Type.String{},

--- a/web/graphql/schema.ex
+++ b/web/graphql/schema.ex
@@ -1,4 +1,4 @@
-defmodule TestSchema do
+defmodule EdmBackend.GraphQL.Schema do
   def schema do
     %GraphQL.Schema{
       query: %GraphQL.Type.ObjectType{
@@ -11,7 +11,7 @@ defmodule TestSchema do
                 type: %GraphQL.Type.String{}
               }
             },
-            resolve: {TestSchema, :greeting}
+            resolve: {EdmBackend.GraphQL.Schema, :greeting}
           }
         }
       }

--- a/web/graphql/schema.ex
+++ b/web/graphql/schema.ex
@@ -2,7 +2,7 @@ defmodule EdmBackend.GraphQL.Schema do
   def schema do
     %GraphQL.Schema{
       query: %GraphQL.Type.ObjectType{
-        name: "Helloo",
+        name: "Hello",
         fields: %{
           greeting: %{
             type: %GraphQL.Type.String{},

--- a/web/router.ex
+++ b/web/router.ex
@@ -33,8 +33,8 @@ defmodule EdmBackend.Router do
   scope "/api/v1/" do
     pipe_through :api
 
-    get "/graphql", GraphQL.Plug, schema: {TestSchema, :schema}
-    post "/graphql", GraphQL.Plug, schema: {TestSchema, :schema}
+    get "/graphql", GraphQL.Plug, schema: {EdmBackend.GraphQL.Schema, :schema}
+    post "/graphql", GraphQL.Plug, schema: {EdmBackend.GraphQL.Schema, :schema}
 
     resources "/client/", EdmBackend.V1.ClientRegistrationController, only: [:create, :index]
 


### PR DESCRIPTION
* Basic graphql/relay support with demo schema+data.
* `schema.json` file is autogenerated and updated on changes to the graphql schema using `eye_drops`